### PR TITLE
Fix broken inheritance call with v0.14.

### DIFF
--- a/lib/fluent/plugin/in_cloudfront_log.rb
+++ b/lib/fluent/plugin/in_cloudfront_log.rb
@@ -1,3 +1,5 @@
+require  'fluent/input'
+
 class Fluent::Cloudfront_LogInput < Fluent::Input
   Fluent::Plugin.register_input('cloudfront_log', self)
 


### PR DESCRIPTION
This is a temporary repo that contains a fix for v0.14 error. Once PR
below is merged into upstream, this repo shall be deprecated or deleted.

Fix broken inheritance call with v0.14.
PR: https://github.com/kubihie/fluent-plugin-cloudfront-log/issues/8