### PR TITLE
Fix broken inheritance call with v0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Fluent::Plugin::Cloudfront::Log
 This plugin will connect to the S3 bucket that you store your cloudfront logs in. Once the plugin processes them and ships them to FluentD, it moves them to another location(either another bucket or sub directory).
 
+This is a fork of https://github.com/kubihie/fluent-plugin-cloudfront-log with a
+fix with regards to fluentd v0.14 error. This is a temporary gem that I would
+publish until PR https://github.com/kubihie/fluent-plugin-cloudfront-log/pull/9
+is merged.
+
 ## Example config
 ```
 <source>
@@ -82,4 +87,8 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/kubihie/fluent-plugin-cloudfront-log.
+
+## Credits
+
+kubihie
 

--- a/fluent-plugin-cloudfront-log.gemspec
+++ b/fluent-plugin-cloudfront-log.gemspec
@@ -3,14 +3,14 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
-  spec.name          = "fluent-plugin-cloudfront-log"
-  spec.version       = "0.0.5"
-  spec.authors       = ["kubihie"]
-  spec.email         = ["kubihie@gmail.com"]
+  spec.name          = "fluent-plugin-cloudfront-log-v0.14-fix"
+  spec.version       = "0.0.1"
+  spec.authors       = ["lenfree"]
+  spec.email         = ["lenfree.yeung@gmail.com"]
 
-  spec.summary       = %q{AWS CloudFront log input plugin.}
-  spec.description   = %q{AWS CloudFront log input plugin for fluentd.}
-  spec.homepage      = "https://github.com/kubihie/fluent-plugin-cloudfront-log"
+  spec.summary       = %q{AWS CloudFront log input plugin with temporary fix for v0.14. Credit to kubihie.}
+  spec.description   = %q{AWS CloudFront log input plugin for fluentd. This repo is temporary until PR to upstream is addressed.}
+  spec.homepage      = "https://github.com/packetloop/fluent-plugin-cloudfront-log-v0.14-fix"
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/lib/fluent/plugin/in_cloudfront_log.rb
+++ b/lib/fluent/plugin/in_cloudfront_log.rb
@@ -1,3 +1,5 @@
+require  'fluent/input'
+
 class Fluent::Cloudfront_LogInput < Fluent::Input
   Fluent::Plugin.register_input('cloudfront_log', self)
 


### PR DESCRIPTION
This is a temporary repo that contains a fix for v0.14 error. Once PR
below is merged into upstream, this repo shall be deprecated or deleted.

Fix broken inheritance call with v0.14.

PR  https://github.com/kubihie/fluent-plugin-cloudfront-log/issues/8